### PR TITLE
[semver:minor] Add support to override the CI install command 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2021-06-04
+
+### Added
+
+- Support to override the CI install command used by the Node orb to install packages
+
 ## [1.1.0] - 2021-05-12
 
 ### Added

--- a/src/examples/a_validate_copyleft_job.yml
+++ b/src/examples/a_validate_copyleft_job.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    license-checker: monito/license-checker@1.1.0
+    license-checker: monito/license-checker@1.2.0
   workflows:
     check-production-licenses:
       jobs:

--- a/src/examples/a_validate_job.yml
+++ b/src/examples/a_validate_job.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    license-checker: monito/license-checker@1.1.0
+    license-checker: monito/license-checker@1.2.0
   workflows:
     check-production-licenses:
       jobs:

--- a/src/examples/override_validate_job.yml
+++ b/src/examples/override_validate_job.yml
@@ -6,7 +6,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    license-checker: monito/license-checker@1.1.0
+    license-checker: monito/license-checker@1.2.0
   workflows:
     check-production-licenses:
       jobs:

--- a/src/jobs/validate-copyleft.yml
+++ b/src/jobs/validate-copyleft.yml
@@ -20,6 +20,12 @@ parameters:
     enum: [npm, yarn]
     default: yarn
     description: The package manager to use to install the node modules
+  override-ci-command:
+    type: string
+    default: ""
+    description: >
+      By default, packages will be installed with "npm ci", "yarn install --frozen-lockfile" or "yarn install --immutable".
+      Optionally supply a custom package installation command, with any additional flags needed.
   forbidden:
     type: string
     default: "GPL;LGPL;CC-BY;Berkeley;AGPL;MPL;EPL;CDDL;CPL"
@@ -45,6 +51,7 @@ steps:
   - node/install-packages:
       pkg-manager: << parameters.pkg-manager >>
       app-dir: << parameters.app-dir >>
+      override-ci-command: << parameters.override-ci-command >>
   - run:
       name: Production License Check
       command: npx license-checker --production --summary --excludePrivatePackages --failOn "<< parameters.forbidden >>"

--- a/src/jobs/validate.yml
+++ b/src/jobs/validate.yml
@@ -19,6 +19,12 @@ parameters:
     enum: [npm, yarn]
     default: yarn
     description: The package manager to use to install the node modules
+  override-ci-command:
+    type: string
+    default: ""
+    description: >
+      By default, packages will be installed with "npm ci", "yarn install --frozen-lockfile" or "yarn install --immutable".
+      Optionally supply a custom package installation command, with any additional flags needed.
   forbidden:
     type: string
     default: ""
@@ -36,6 +42,7 @@ steps:
   - node/install-packages:
       pkg-manager: << parameters.pkg-manager >>
       app-dir: << parameters.app-dir >>
+      override-ci-command: << parameters.override-ci-command >>
   - run:
       name: Production License Check
       command: npx license-checker --production --summary --excludePrivatePackages --failOn "<< parameters.forbidden >>"


### PR DESCRIPTION
**SEMVER Update Type:**

- [ ] Major
- [X] Minor
- [ ] Patch

## Description:

Add support to override the CI install command used by the Node orb to install packages.

## Motivation:

Some projects have specific needs regarding the package installation (for instance, installing only the production packages)


## Checklist:

- [X] All new jobs, commands, executors, parameters have descriptions.
- [X] Usage Example version numbers have been updated.
- [X] Changelog has been updated.
