### PR TITLE
ci: specify tag filters everywhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,10 @@ workflows:
   # This workflow will run on every commit
   test-pack:
     jobs:
-      - orb-tools/lint # Lint Yaml files
-      - orb-tools/pack # Pack orb source
+      - orb-tools/lint: # Lint Yaml files
+          filters: *filters
+      - orb-tools/pack: # Pack orb source
+          filters: *filters
 
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:


### PR DESCRIPTION
**SEMVER Update Type:**

- [ ] Major
- [ ] Minor
- [ ] Patch

NA
## Description:
- specifiy a tag filter everywhere

## Motivation:
CircleCI won't run a job on a tag if there is no tag filter specified or on any of its dependency.

## Checklist:
NA
- [ ] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.
