### PR TITLE
feat!: check dev dependencies and exclude private packages by default

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -34,6 +34,12 @@ jobs:
           app-dir: data-fixtures
       - license-checker/validate:
           app-dir: data-fixtures
+          production-only: true
+      - license-checker/validate:
+          app-dir: data-fixtures
+          exclude-private: false
+      - license-checker/validate:
+          app-dir: data-fixtures
           forbidden: GPL;LGPL;Forbidden license
       - license-checker/validate-copyleft:
           app-dir: data-fixtures
@@ -47,6 +53,11 @@ workflows:
       - license-checker/validate:
           name: integration-test-jobs-default
           app-dir: data-fixtures
+          filters: *filters
+      - license-checker/validate:
+          name: integration-test-jobs-production-only
+          app-dir: data-fixtures
+          production-only: true
           filters: *filters
       - license-checker/validate:
           name: integration-test-jobs-override
@@ -68,6 +79,7 @@ workflows:
             - orb-tools/pack
             - integration-test-jobs-copyleft-default
             - integration-test-jobs-default
+            - integration-test-jobs-production-only
             - integration-test-jobs-override
             - integration-test-commands
           context: orb-publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0]
+
+### Changed
+
+- **BREAKING:** Development dependencies are now checked and reported by default. Previously only production dependencies were validated. Set `production-only: true` to restore the previous behavior.
+- **BREAKING:** The production CSV report artifact is now named `<report-name>-production.csv` (was `<report-name>.csv`). Update any tooling that consumes the report by its previous path.
+- Update license
+- Upgrade circleci/node version
+
+### Added
+
+- A separate CSV report is now generated for development dependencies: `<report-name>-development.csv`.
+- `production-only` option (false by default) to restrict the checks and reports to production dependencies.
+- `exclude-private` option (true by default) to exclude private packages from the checks and reports.
 
 ## [3.0.2]
 
@@ -16,7 +30,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Update `orb-tools` and CI
-
 
 ## [3.0.0]
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2013-2023 Monito - Global Impact Finance SA
+Copyright (c) 2013-2026 Monito - Global Impact Finance SA
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # License Checker Orb [![CircleCI Build Status](https://circleci.com/gh/monito/license-checker-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/monito/license-checker-orb) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/monito/license-checker-orb/main/LICENSE)
 
-A Circle CI orb to check licenses used in production, based on [license-checker](https://www.npmjs.com/package/license-checker)
+A Circle CI orb to check the licenses used by your project (production and development dependencies), based on [license-checker](https://www.npmjs.com/package/license-checker)
 
 ## Usage
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -2,12 +2,12 @@ version: 2.1
 
 description: >
   Integrate the license-checker check into your build.
-  Get a report about the production licenses used by your project.
-  Optionally fail your build based on a list of forbidden licenses.
+  Get a report about the licenses used by your project, for both production and development dependencies.
+  Optionally restrict the check to production dependencies, and fail your build based on a list of forbidden licenses.
 
 display:
-  home_url: "https://github.com/monito"
-  source_url: "https://github.com/monito/license-checker-orb"
+  home_url: 'https://github.com/monito'
+  source_url: 'https://github.com/monito/license-checker-orb'
 
 orbs:
-  node: circleci/node@5.0.2
+  node: circleci/node@5

--- a/src/commands/validate-copyleft.yml
+++ b/src/commands/validate-copyleft.yml
@@ -1,14 +1,20 @@
 description: >
-  Command to validate none of your licenses used in production are Copyleft licenses.
+  Command to validate none of your licenses are Copyleft licenses.
+  By default both production and development dependencies are checked.
   Copyleft software licenses are considered protective or reciprocal in contrast with permissive free software licenses.
   If one of the Copyleft license is found the build will fail.
-  A CSV report with all licences is uploaded as a build artifact.
+  A CSV report is uploaded as a build artifact for each dependency set (production and development).
 
 parameters:
   app-dir:
     type: string
     default: .
     description: The location of the package.json and associated node_modules
+  exclude-private:
+    type: boolean
+    default: true
+    description: >
+      When true (the default), private packages are excluded from the checks and the reports.
   forbidden:
     type: string
     default: "GPL;LGPL;CC-BY;Berkeley;AGPL;MPL;EPL;CDDL;CPL"
@@ -23,13 +29,22 @@ parameters:
         Eclipse Public License (EPL)
         Common Development and Distribution License (CDDL)
         Common Public License (CPL)
+  production-only:
+    type: boolean
+    default: false
+    description: >
+      When true, only production dependencies are checked and reported.
+      By default both production and development dependencies are validated.
   report-name:
     type: string
     default: license-checker-report
     description: >
-      Name of the license checker report artifact.
+      Base name of the license checker report artifacts.
+      Reports are suffixed with "-production" and "-development".
 steps:
   - validate:
       app-dir: << parameters.app-dir >>
       report-name: << parameters.report-name >>
       forbidden: << parameters.forbidden >>
+      production-only: << parameters.production-only >>
+      exclude-private: << parameters.exclude-private >>

--- a/src/commands/validate.yml
+++ b/src/commands/validate.yml
@@ -1,40 +1,83 @@
 description: >
-  Command to validate the licenses used in production.
-  A list of forbidden licenses can be provided. If one of the license is found the build will fail.
-  A CSV report with all licences is uploaded as a build artifact.
+  Command to validate the licenses used by your project.
+  By default both production and development dependencies are checked.
+  A list of forbidden licenses can be provided. If one of the licenses is found the build will fail.
+  A CSV report is uploaded as a build artifact for each dependency set (production and development).
 
 parameters:
   app-dir:
     type: string
     default: .
     description: The location of the package.json and associated node_modules
+  exclude-private:
+    type: boolean
+    default: true
+    description: >
+      When true (the default), private packages are excluded from the checks and the reports.
   forbidden:
     type: string
     default: ""
     description: >
       A semi colon separated list of forbidden licenses.
       If no value is provided the license check won't fail.
+  production-only:
+    type: boolean
+    default: false
+    description: >
+      When true, only production dependencies are checked and reported.
+      By default both production and development dependencies are validated.
   report-name:
     type: string
     default: license-checker-report
     description: >
-      Name of the license checker report artifact.
+      Base name of the license checker report artifacts.
+      Reports are suffixed with "-production" and "-development".
 steps:
   - run:
+      name: Configure license-checker options
+      command: |
+        if [ "<< parameters.exclude-private >>" = "true" ]; then
+          echo 'export LC_EXCLUDE_PRIVATE="--excludePrivatePackages"' >> "$BASH_ENV"
+        else
+          echo 'export LC_EXCLUDE_PRIVATE=""' >> "$BASH_ENV"
+        fi
+  - run:
       name: Production License Check
-      command: npx license-checker --production --summary --excludePrivatePackages --failOn "<< parameters.forbidden >>"
+      command: npx license-checker --production --summary $LC_EXCLUDE_PRIVATE --failOn "<< parameters.forbidden >>"
       working_directory: << parameters.app-dir >>
   - run:
       name: Production license summary
-      command: npx license-checker --production --summary --excludePrivatePackages
+      command: npx license-checker --production --summary $LC_EXCLUDE_PRIVATE
       working_directory: << parameters.app-dir >>
       when: on_fail
   - run:
       name: Build production license report
-      command: npx license-checker --production --excludePrivatePackages --csv > /tmp/<< parameters.report-name >>.csv
+      command: npx license-checker --production $LC_EXCLUDE_PRIVATE --csv > /tmp/<< parameters.report-name >>-production.csv
       working_directory: << parameters.app-dir >>
       when: always
   - store_artifacts:
-      path: /tmp/<< parameters.report-name >>.csv
-      destination: << parameters.app-dir >>/<< parameters.report-name >>.csv
+      path: /tmp/<< parameters.report-name >>-production.csv
+      destination: << parameters.app-dir >>/<< parameters.report-name >>-production.csv
       when: always
+  - when:
+      condition:
+        not: << parameters.production-only >>
+      steps:
+        - run:
+            name: Development License Check
+            command: npx license-checker --development --summary $LC_EXCLUDE_PRIVATE --failOn "<< parameters.forbidden >>"
+            working_directory: << parameters.app-dir >>
+        - run:
+            name: Development license summary
+            command: npx license-checker --development --summary $LC_EXCLUDE_PRIVATE
+            working_directory: << parameters.app-dir >>
+            when: on_fail
+        - run:
+            name: Build development license report
+            command: npx license-checker --development $LC_EXCLUDE_PRIVATE --csv > /tmp/<< parameters.report-name >>-development.csv
+            working_directory: << parameters.app-dir >>
+            when: always
+        - store_artifacts:
+            path: /tmp/<< parameters.report-name >>-development.csv
+            destination: << parameters.app-dir >>/<< parameters.report-name >>-development.csv
+            when: always

--- a/src/examples/override_validate_job.yml
+++ b/src/examples/override_validate_job.yml
@@ -1,18 +1,19 @@
 description: >
-  Drop-in solution to automatically check your production licenses.
+  Drop-in solution to automatically check your licenses.
   This job will automatically install your application dependencies, install the license-checker, execute it, produce a summary and a report.
   Based on the given list of forbidden licenses, the build will fail if one is detected.
-  You can also override the node version, the package manager, or the application directory.
+  You can restrict the check to production dependencies with production-only, and override the node version, the package manager, or the application directory.
 usage:
   version: 2.1
   orbs:
     license-checker: monito/license-checker@x.y
   workflows:
-    check-production-licenses:
+    check-licenses:
       jobs:
         - license-checker/validate:
             name: validate-with-against-a-forbidden-list
             forbidden: GPL;LGPL;Forbidden license
+            production-only: true
             node-version: 14.16.0
             pkg-manager: yarn
             app-dir: where-the-node-modules-are

--- a/src/jobs/validate-copyleft.yml
+++ b/src/jobs/validate-copyleft.yml
@@ -1,14 +1,20 @@
 description: >
-  Drop-in job to validate none of your licenses used in production are Copyleft licenses.
+  Drop-in job to validate none of your licenses are Copyleft licenses.
+  By default both production and development dependencies are checked.
   Copyleft software licenses are considered protective or reciprocal in contrast with permissive free software licenses.
   If one of the Copyleft license is found the build will fail.
-  A CSV report with all licences is uploaded as a build artifact.
+  A CSV report is uploaded as a build artifact for each dependency set (production and development).
 
 parameters:
   app-dir:
     type: string
     default: .
     description: The location of the package.json and associated node_modules
+  exclude-private:
+    type: boolean
+    default: true
+    description: >
+      When true (the default), private packages are excluded from the checks and the reports.
   node-version:
     type: string
     default: lts
@@ -28,11 +34,18 @@ parameters:
     description: >
       By default, packages will be installed with "npm ci", "yarn install --frozen-lockfile" or "yarn install --immutable".
       Optionally supply a custom package installation command, with any additional flags needed.
+  production-only:
+    type: boolean
+    default: false
+    description: >
+      When true, only production dependencies are checked and reported.
+      By default both production and development dependencies are validated.
   report-name:
     type: string
     default: license-checker-report
     description: >
-      Name of the license checker report artifact.
+      Base name of the license checker report artifacts.
+      Reports are suffixed with "-production" and "-development".
 
 executor:
   name: default
@@ -46,4 +59,6 @@ steps:
       override-ci-command: << parameters.override-ci-command >>
   - validate-copyleft:
       app-dir: << parameters.app-dir >>
+      production-only: << parameters.production-only >>
+      exclude-private: << parameters.exclude-private >>
       report-name: << parameters.report-name >>

--- a/src/jobs/validate.yml
+++ b/src/jobs/validate.yml
@@ -1,13 +1,19 @@
 description: >
-  Drop-in job to validate the licenses used in production.
-  A list of forbidden licenses can be provided. If one of the license is found the build will fail.
-  A CSV report with all licences is uploaded as a build artifact.
+  Drop-in job to validate the licenses used by your project.
+  By default both production and development dependencies are checked.
+  A list of forbidden licenses can be provided. If one of the licenses is found the build will fail.
+  A CSV report is uploaded as a build artifact for each dependency set (production and development).
 
 parameters:
   app-dir:
     type: string
     default: .
     description: The location of the package.json and associated node_modules
+  exclude-private:
+    type: boolean
+    default: true
+    description: >
+      When true (the default), private packages are excluded from the checks and the reports.
   node-version:
     type: string
     default: lts
@@ -33,11 +39,18 @@ parameters:
     description: >
       A semi colon separated list of forbidden licenses.
       If no value is provided the license check won't fail.
+  production-only:
+    type: boolean
+    default: false
+    description: >
+      When true, only production dependencies are checked and reported.
+      By default both production and development dependencies are validated.
   report-name:
     type: string
     default: license-checker-report
     description: >
-      Name of the license checker report artifact.
+      Base name of the license checker report artifacts.
+      Reports are suffixed with "-production" and "-development".
 
 executor:
   name: default
@@ -52,4 +65,6 @@ steps:
   - validate:
       forbidden: << parameters.forbidden >>
       app-dir: << parameters.app-dir >>
+      production-only: << parameters.production-only >>
+      exclude-private: << parameters.exclude-private >>
       report-name: << parameters.report-name >>


### PR DESCRIPTION
## Summary

Validate licenses for both production **and development** dependencies instead of production only. A separate CSV report is generated for each dependency set, and two new options give control over scope.

- `production-only` (default `false`) — restrict checks and reports to production dependencies.
- `exclude-private` (default `true`) — exclude private packages from checks and reports.

Both options are threaded through the `validate` and `validate-copyleft` commands and their drop-in jobs.

## Behavior changes

- **Dev dependencies are now validated by default.** The same `forbidden` list applies to prod and dev, so a forbidden license in either fails the build. Set `production-only: true` to restore the previous production-only behavior.
- **Reports are now suffixed by scope:** the production report is renamed `<report-name>-production.csv` (was `<report-name>.csv`), and a `<report-name>-development.csv` is added.

⚠️ **Breaking** — see the `BREAKING CHANGE` notes in the commit and the `[4.0.0]` CHANGELOG entry. Downstream consumers that read the report by its old path must update it.

## Implementation notes

- The `exclude-private` flag is computed once into `$BASH_ENV` (`LC_EXCLUDE_PRIVATE`) and referenced by all six `license-checker` invocations, avoiding duplicated `when`/`unless` blocks.
- Development steps are gated by a `when: { not: production-only }` logic block in [src/commands/validate.yml](src/commands/validate.yml).

## Testing

- Added integration cases to [.circleci/test-deploy.yml](.circleci/test-deploy.yml) exercising `production-only: true` (command + job level) and `exclude-private: false`.
- `circleci orb pack src` succeeds locally; `orb validate` / `config validate` run in CI (require an API token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)