### PR TITLE
docs: document the publication workflow (and bump orb dependencies)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@12.0
-  node: circleci/node@4.3.0
+  orb-tools: circleci/orb-tools@12
 
 filters: &filters
   tags:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -2,10 +2,10 @@ version: 2.1
 orbs:
   # Your orb will be automatically injected here during the pipeline.
   # Reference your orb's jobs and commands below as they will exist when built.
-  orb-tools: circleci/orb-tools@12.0
+  orb-tools: circleci/orb-tools@12
   # The orb definition is intentionally not included here. It will be injected into the pipeline.
   license-checker: {}
-  node: circleci/node@4.3.0
+  node: circleci/node@7
 
 # Use this tag to ensure test jobs always run,
 # even though the downstream publish job will only run on release tags.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,31 @@ A Circle CI orb to check the licenses used by your project (production and devel
 
 For full usage guidelines, see the [orb registry listing](https://circleci.com/developer/orbs/orb/monito/license-checker).
 
+## Releasing
+
+Publishing a new version of the orb is **driven by git tags**. The CI is split into two pipelines (the [Orb Development Kit](https://circleci.com/docs/orb-author/) layout):
+
+- [`.circleci/config.yml`](.circleci/config.yml) — the *setup* pipeline. On every commit it lints and packs the orb source, then triggers the `test-deploy` pipeline.
+- [`.circleci/test-deploy.yml`](.circleci/test-deploy.yml) — runs the integration tests on every commit, and **publishes to the registry only when a release tag is pushed**.
+
+A production version is published when a tag matching `^v[0-9]+\.[0-9]+\.[0-9]+$` (e.g. `v4.0.0`) is pushed. The `orb-tools/publish` job (gated on that tag and on all tests passing) publishes `monito/license-checker@X.Y.Z` to the registry — the orb version is the tag without the leading `v`.
+
+### Cutting a release
+
+1. Choose the next [semantic version](https://semver.org/) for the change (major / minor / patch).
+2. Update [`CHANGELOG.md`](CHANGELOG.md) with the new version and merge it to `main`.
+3. From `main`, create and push the matching tag:
+
+   ```bash
+   git checkout main && git pull
+   git tag v4.0.0
+   git push origin v4.0.0
+   ```
+
+4. CircleCI validates the orb (lint, pack, integration tests) and, on success, publishes the new version to the registry.
+
+> Publishing requires an organization-owner CircleCI API token, supplied to the `orb-tools/publish` job via the `orb-publishing` [context](https://circleci.com/docs/contexts/).
+
 ## Contributing
 
 We welcome [issues](https://github.com/monito/license-checker-orb/issues) to and [pull requests](https://github.com/monito/license-checker-orb/pulls) against this repository!

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,4 +10,4 @@ display:
   source_url: 'https://github.com/monito/license-checker-orb'
 
 orbs:
-  node: circleci/node@5
+  node: circleci/node@7


### PR DESCRIPTION
## Summary

Adds documentation for how this orb is published, and carries the pending orb dependency bump (which is not yet on `main`).

This branch contains two commits:

- **docs: releasing** — a new **Releasing** section in `README.md` explaining the tag-driven publication workflow: the two-pipeline (setup → test-deploy) layout, that a production version is published when a `^v[0-9]+\.[0-9]+\.[0-9]+$` tag is pushed, a step-by-step "cutting a release" checklist, and the `orb-publishing` context requirement.
- **chore: upgrade orbs versions** — `circleci/orb-tools` `12.0`→`12` and `circleci/node` `5`/`4.3.0`→`7`, plus removal of the unused `node` orb from the setup config. (Verified: the orb only consumes `node/install-packages`, whose parameters are unchanged across v5→v7; the v6/v7 breaking changes affect the `install` command and executor, which this orb does not use.)

Deployment remains **tag-driven** — no changes to the release mechanism itself.

## Test plan

- `circleci orb pack src` succeeds (orb source still valid).
- Docs only otherwise; no behavior change to jobs/commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)