### PR TITLE
fix: prune correctly when a Yarn Berry repo is passed as pkg-manager=yarn

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -84,6 +84,34 @@ jobs:
               echo "FAIL: forbidding MIT did not trip the gate over the production closure"; exit 1
             fi
             echo "OK: forbidding MIT trips the gate (workspace prod dep is seen)"
+  # Regression test for a Yarn Berry repo that is (mis)classified as plain "yarn".
+  # The prune step must detect the real Yarn version at runtime and use
+  # "yarn workspaces focus" rather than the legacy "--production --frozen-lockfile"
+  # flags, which are fatal on Yarn Berry (YN0050).
+  integration-test-monorepo-misclassified-as-yarn:
+    docker:
+      - image: cimg/node:22.13
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn-berry
+          app-dir: data-fixtures-monorepo
+      - license-checker/validate:
+          app-dir: data-fixtures-monorepo
+          # Deliberately wrong: this is a Yarn Berry repo, but callers (or auto-detection)
+          # sometimes pass plain "yarn". The prune step must still succeed.
+          pkg-manager: yarn
+          exclude-private: false
+          report-name: misclassified-report
+      - run:
+          name: Assert the production report was still built correctly
+          working_directory: data-fixtures-monorepo
+          command: |
+            grep -iq '"ms@' /tmp/misclassified-report-production.csv \
+              || { echo "FAIL: ms (workspace app prod dep) missing from production report"; exit 1; }
+            grep -iq '"chalk@' /tmp/misclassified-report-production.csv \
+              && { echo "FAIL: chalk (devDependency) leaked into production report"; exit 1; }
+            echo "OK: prune succeeded and production report is correct despite pkg-manager=yarn"
 workflows:
   test-deploy:
     jobs:
@@ -111,6 +139,8 @@ workflows:
           filters: *filters
       - integration-test-monorepo:
           filters: *filters
+      - integration-test-monorepo-misclassified-as-yarn:
+          filters: *filters
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -126,5 +156,6 @@ workflows:
             - integration-test-jobs-override
             - integration-test-commands
             - integration-test-monorepo
+            - integration-test-monorepo-misclassified-as-yarn
           context: orb-publishing
           filters: *release-filters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.1]
+
+### Fixed
+
+- The "Prune node_modules to the production closure" step no longer fails on Yarn Berry
+  repositories that are passed (or auto-detected) as `pkg-manager: yarn`. Previously the
+  classic-`yarn` path always ran `yarn install --production --frozen-lockfile`, and both
+  flags are removed and fatal on Yarn Berry (`YN0050`), aborting the build. The prune step
+  now detects the actual Yarn major version at runtime and uses
+  `yarn workspaces focus --all --production` on Yarn Berry (>= 2) while keeping the legacy
+  flags for Yarn Classic (1.x), so both `yarn` and `yarn-berry` work on any Yarn version.
+
 ## [5.0.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ package manager itself, then scans what remains:
 | `pkg-manager` | production prune |
 |---|---|
 | `npm` | `npm ci --omit=dev` |
-| `yarn` | `yarn install --production --frozen-lockfile` |
-| `yarn-berry` | `yarn workspaces focus --all --production` |
+| `yarn` / `yarn-berry` | `yarn workspaces focus --all --production` on Yarn Berry (>= 2), `yarn install --production --frozen-lockfile` on Yarn Classic (1.x) — the actual Yarn version is detected at runtime |
 | `pnpm` | `pnpm install --prod --frozen-lockfile` |
 
 Two CSV artifacts are produced:

--- a/src/commands/validate.yml
+++ b/src/commands/validate.yml
@@ -25,8 +25,10 @@ parameters:
     description: >
       The package manager used to install the node modules. It selects how node_modules is
       pruned to the production closure before the production report is generated
-      (npm: "npm ci --omit=dev"; yarn: "yarn install --production --frozen-lockfile";
-      yarn-berry: "yarn workspaces focus --all --production"; pnpm: "pnpm install --prod --frozen-lockfile").
+      (npm: "npm ci --omit=dev"; pnpm: "pnpm install --prod --frozen-lockfile"). For yarn
+      and yarn-berry the actual Yarn version is detected at runtime: Yarn Classic (1.x) uses
+      "yarn install --production --frozen-lockfile", Yarn Berry (>= 2) uses
+      "yarn workspaces focus --all --production", so passing either value works for any Yarn version.
       Job callers inherit this from the job's pkg-manager; direct command callers must set it
       to match their project.
   exclude-private:
@@ -89,11 +91,20 @@ steps:
           npm)
             npm ci --omit=dev
             ;;
-          yarn)
-            yarn install --production --frozen-lockfile
-            ;;
-          yarn-berry)
-            yarn workspaces focus --all --production
+          yarn|yarn-berry)
+            # The pkg-manager parameter often misclassifies the Yarn flavour (e.g. a Yarn
+            # Berry repo passed as plain "yarn"), so detect the actual major version at
+            # runtime and prune with the command that version supports.
+            yarn_major="$(yarn --version | cut -d. -f1)"
+            if [ "${yarn_major:-1}" -ge 2 ]; then
+              # Yarn Berry (>= 2): --production / --frozen-lockfile are removed and fatal.
+              # "workspaces focus --all" installs the production closure of every workspace
+              # (and of the root, which is itself a workspace), so it also covers single-package repos.
+              yarn workspaces focus --all --production
+            else
+              # Yarn Classic (1.x): no "workspaces focus" command; use the legacy flags.
+              yarn install --production --frozen-lockfile
+            fi
             ;;
           pnpm)
             pnpm install --prod --frozen-lockfile


### PR DESCRIPTION
## Problem

`license-checker/validate-copyleft` (and `validate`) fail at the **Prune node_modules to the production closure** step for consumer repos whose Yarn Berry projects are classified as plain `yarn` (the array-form `workspaces` case). The whole step output is just:

```
YN0050: The --production option is deprecated on 'install'; use 'yarn workspaces focus' instead
YN0050: The --frozen-lockfile option is deprecated; use --immutable and/or --immutable-cache instead
Exited with code exit status 1
```

## Root cause

The prune step branches purely on the `pkg-manager` parameter — there is no workspace-shape logic in the orb (that branching lives in the *consumer's* config generation, which maps array-form `workspaces` → `yarn` and object-form → `yarn-berry`). So array-form-workspace repos arrive as `pkg-manager: yarn` (classic) while actually running **Yarn Berry 4.x**, where `yarn install --production --frozen-lockfile` is fatal (`YN0050`), aborting before any install.

Reproduced locally against `data-fixtures-monorepo` (Yarn 4.9.1): the legacy command exits 1 with the exact errors; `yarn workspaces focus --all --production` exits 0.

## Fix

Merge the `yarn` and `yarn-berry` cases and **detect the actual Yarn major version at runtime**:

- Yarn Berry (>= 2) → `yarn workspaces focus --all --production` (modern, supported; `workspace-tools` is bundled in Yarn 3/4)
- Yarn Classic (1.x) → `yarn install --production --frozen-lockfile` (legacy flags still correct; `workspaces focus` doesn't exist there)

This is more robust than only fixing the `yarn-berry` branch: the failing repos never *reach* that branch — they come in as `yarn`. Runtime detection fixes the misclassification without breaking genuine Yarn 1.x, so both `yarn` and `yarn-berry` now work on any Yarn version.

## Tests

- Added `integration-test-monorepo-misclassified-as-yarn` to `test-deploy.yml`: installs the Berry monorepo fixture but passes `pkg-manager: yarn`, asserting the prune succeeds and the production report is correct (`ms` present, `chalk` devDep absent). Wired into the workflow and the publish `requires` list.
- End-to-end local simulation of the new prune logic + report build passes.

Also updated the `pkg-manager` parameter description, the README prune table, and `CHANGELOG.md` (`[5.0.1]`).

## Release

Ship as **v5.0.1**. Consumer repos in this refresh pin `monito/license-checker@5`, so they pick up the fix on the next CI run — no consumer PR changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)